### PR TITLE
Update application.yaml

### DIFF
--- a/examples/modules/application/application.yaml
+++ b/examples/modules/application/application.yaml
@@ -31,7 +31,7 @@ Mappings:
     us-east-2:
       AMI: ami-0ab8744dca8137bde
     us-east-1:
-      AMI: ami-00543d76373f96fe7
+      AMI: ami-0c7af5fe939f2677f
     us-gov-east-1:
       AMI: ami-08db47abb3873cf32
     us-gov-west-1:


### PR DESCRIPTION
updated us-east-1 AMI ID to a RHEL 9 image
The current AMI was failing with error "AMI ID not found"

@<reviewer_id>

#### What issues does this address?
Fixes # Fixes current failing AMI ID for us-east-1
WIP #<issueid>
...

#### What does this change do?  Fixes the failing application EC2 instance when a sample app is selected

#### Where should the reviewer start?

#### Any background context?
